### PR TITLE
Add `FileTime::to_raw`

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -14,10 +14,15 @@ toc::[]
 
 == {compare-url}/v0.4.1\...HEAD[Unreleased]
 
+=== Added
+
+* Add `FileTime::to_raw` as an alternative to `FileTime::as_u64`
+
 === Changed
 
 * Change to use `datetime` macro in doctests
 * Bump MSRV to 1.65.0
+* Change `FileTime::as_u64` to deprecated
 
 == {compare-url}/v0.4.0\...v0.4.1[0.4.1] - 2023-04-25
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ assert_eq!(
     OffsetDateTime::try_from(ft).unwrap(),
     OffsetDateTime::UNIX_EPOCH
 );
-assert_eq!(ft.as_u64(), 116_444_736_000_000_000);
+assert_eq!(ft.to_raw(), 116_444_736_000_000_000);
 
 assert_eq!(FileTime::new(u64::MAX), FileTime::MAX);
 ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,7 @@
 //!     OffsetDateTime::try_from(ft).unwrap(),
 //!     OffsetDateTime::UNIX_EPOCH
 //! );
-//! assert_eq!(ft.as_u64(), 116_444_736_000_000_000);
+//! assert_eq!(ft.to_raw(), 116_444_736_000_000_000);
 //!
 //! assert_eq!(FileTime::new(u64::MAX), FileTime::MAX);
 //! ```


### PR DESCRIPTION
This is an alternative to `FileTime::as_u64`. Also, change `FileTime::as_u64` to deprecated.